### PR TITLE
fix: Scarb.toml readme & license file not resolved

### DIFF
--- a/crates/cli/src/verify.rs
+++ b/crates/cli/src/verify.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::{arg, builder::PossibleValue, Args, ValueEnum};
 use serde::{Deserialize, Serialize};
+use voyager_resolver_cairo::compiler::scarb_utils::read_additional_scarb_manifest_metadata;
 use walkdir::{DirEntry, WalkDir};
 
 use dyn_compiler::dyn_compiler::{SupportedCairoVersions, SupportedScarbVersions};
@@ -97,17 +98,6 @@ pub struct VerifyFileArgs {
     path: Utf8PathBuf,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct ScarbTomlRawPackageData {
-    name: String,
-    version: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ScarbTomlRawData {
-    package: ScarbTomlRawPackageData,
-}
-
 pub fn verify_project(
     args: VerifyProjectArgs,
     cairo_version: SupportedCairoVersions,
@@ -150,10 +140,10 @@ pub fn verify_project(
     }
 
     // Read the scarb metadata to get more information
+    // TODO: switch this to using scarb-metadata
     let scarb_toml_content = fs::read_to_string(source_dir.join("Scarb.toml"))?;
-    let scarb_metadata_package_name = toml::from_str::<ScarbTomlRawData>(&scarb_toml_content)?
-        .package
-        .name;
+    let extracted_scarb_toml_data =
+        read_additional_scarb_manifest_metadata(scarb_toml_content.as_str())?;
 
     // Compiler and extract the necessary files
     compiler.compile_project(&source_dir)?;
@@ -164,7 +154,7 @@ pub fn verify_project(
 
     // The compiler compiles into the original scarb package name
     // As such we have to craft the correct path to the main package
-    let project_dir_path = extracted_files_dir.join(scarb_metadata_package_name.clone());
+    let project_dir_path = extracted_files_dir.join(extracted_scarb_toml_data.name.clone());
     let project_dir_path = project_dir_path
         .strip_prefix(extracted_files_dir.clone())
         .unwrap();
@@ -175,13 +165,22 @@ pub fn verify_project(
         .filter_map(|f| f.ok())
         .filter(|f| f.file_type().is_file())
         .filter(|f| {
-            f.path().extension().unwrap() == "cairo"
-                || f.path()
-                    .file_name()
-                    .map(|f| f.to_string_lossy().into_owned())
-                    .unwrap_or("".into())
-                    .to_lowercase()
-                    == "scarb.toml"
+            let file_path = f.path();
+
+            let is_cairo_file = match file_path.extension() {
+                Some(ext) => ext == "cairo",
+                None => false,
+            };
+            let file_entry_name = file_path
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .unwrap_or("".into());
+
+            let is_supplementary_file = file_entry_name.to_lowercase() == "scarb.toml"
+                || file_entry_name == extracted_scarb_toml_data.license_file
+                || file_entry_name == extracted_scarb_toml_data.readme;
+
+            is_cairo_file || is_supplementary_file
         })
         .collect::<Vec<DirEntry>>();
 
@@ -206,7 +205,7 @@ pub fn verify_project(
     // We already know the contract file specified in Scarb.toml is relative to src/
     let contract_file = format!(
         "{}/src/{}",
-        scarb_metadata_package_name.clone(),
+        extracted_scarb_toml_data.name.clone(),
         contract_paths[0].as_str()
     );
 

--- a/crates/voyager-resolver-cairo/src/compiler/mod.rs
+++ b/crates/voyager-resolver-cairo/src/compiler/mod.rs
@@ -169,6 +169,7 @@ impl Compiler for VoyagerGenerator {
             .filter(|m| required_modules_paths.contains(&m.path))
             .collect::<Vec<_>>();
         // Copy these modules in the target directory.
+        // Copy readme files and license files over too
         copy_required_files(&required_modules, &target_dir, ws)?;
 
         // Generate each of the scarb manifest files for the output directory.

--- a/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
+++ b/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, ensure, Context, Result};
 use scarb::flock::Filesystem;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -11,6 +12,44 @@ use cairo_lang_semantic::db::SemanticGroup;
 use scarb::core::Package;
 
 use crate::model::CairoModule;
+
+#[derive(Debug, Deserialize)]
+struct ScarbTomlRawPackageData {
+    name: String,
+    license_file: Option<String>,
+    readme: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScarbTomlRawData {
+    package: ScarbTomlRawPackageData,
+}
+
+#[derive(Debug)]
+pub struct AdditionalScarbManifestMetadata {
+    pub name: String,
+    pub license_file: String,
+    pub readme: String,
+}
+
+// Get the MetadataManifest from the Scarb.toml
+// TODO: replace this with the scarb-metadata as an alternative.
+pub fn read_additional_scarb_manifest_metadata(
+    scarb_toml_content: &str,
+) -> Result<AdditionalScarbManifestMetadata> {
+    let scarb_metadata = toml::from_str::<ScarbTomlRawData>(scarb_toml_content)?;
+
+    let scarb_metadata_package_name = scarb_metadata.package.name;
+    let scarb_metadata_package_license_file =
+        scarb_metadata.package.license_file.unwrap_or("".into());
+    let scarb_metadata_package_readme = scarb_metadata.package.readme.unwrap_or("".into());
+
+    Ok(AdditionalScarbManifestMetadata {
+        name: scarb_metadata_package_name,
+        license_file: scarb_metadata_package_license_file,
+        readme: scarb_metadata_package_readme,
+    })
+}
 
 /// Reads Scarb project metadata from manifest file.
 pub fn read_scarb_metadata(manifest_path: &PathBuf) -> anyhow::Result<scarb_metadata::Metadata> {
@@ -229,4 +268,57 @@ pub fn get_contracts_to_verify(package: &Package) -> Result<Vec<PathBuf>> {
         .collect::<Vec<_>>();
 
     Ok(table_values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_correctly_extract_the_scarb_toml_metadata() {
+        let scarb_toml_content = r#"
+        [package]
+        name = "test_data"
+        version = "0.1.0"
+        license_file = "LICENSE"
+        readme = "README.md"
+        "#;
+
+        let data = read_additional_scarb_manifest_metadata(scarb_toml_content).unwrap();
+
+        assert_eq!(data.name, "test_data");
+        assert_eq!(data.license_file, "LICENSE");
+        assert_eq!(data.readme, "README.md");
+    }
+
+    #[test]
+    fn should_correctly_extract_empty_scarb_toml_metadata() {
+        let scarb_toml_content = r#"
+        [package]
+        name = "test_data_2"
+        version = "0.1.0"
+        "#;
+
+        let data = read_additional_scarb_manifest_metadata(scarb_toml_content).unwrap();
+
+        assert_eq!(data.name, "test_data_2");
+        assert_eq!(data.license_file, "");
+        assert_eq!(data.readme, "");
+    }
+
+    #[test]
+    fn should_correctly_extract_existing_scarb_toml_metadata() {
+        let scarb_toml_content = r#"
+        [package]
+        name = "test_data_2"
+        version = "0.1.0"
+        readme = "README.md"
+        "#;
+
+        let data = read_additional_scarb_manifest_metadata(scarb_toml_content).unwrap();
+
+        assert_eq!(data.name, "test_data_2");
+        assert_eq!(data.license_file, "");
+        assert_eq!(data.readme, "README.md");
+    }
 }


### PR DESCRIPTION
When the contract is being reoslved and a readme or license file is specified in `Scarb.toml`, the contract resolving logic does not move the readme & licnese file, causing a compilation error during `scarb build`.

This PR fixes that by extracing information of these file from `Scarb.toml` and also including them as file being moved to the extracted sub-folder so builds won't fail due to it being missing.

Closes #22.