### PR TITLE
feat: support custom verification apis

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -331,7 +331,10 @@ mod tests {
         // Assert that the internal api is correct
         assert_eq!(actual_network_api.0, "https://sepolia.voyager.online");
         // Assert that the public api is correct``
-        assert_eq!(actual_network_api.1, "https://sepolia-api.voyager.online/beta");
+        assert_eq!(
+            actual_network_api.1,
+            "https://sepolia-api.voyager.online/beta"
+        );
     }
 
     #[test]

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 use std::{str::FromStr, thread::sleep};
 
 use anyhow::{anyhow, Error, Ok, Result};
@@ -15,6 +15,7 @@ pub enum Network {
     Mainnet,
     Sepolia,
     Local,
+    Custom,
 }
 
 impl Display for Network {
@@ -23,6 +24,7 @@ impl Display for Network {
             Network::Mainnet => write!(f, "mainnet"),
             Network::Sepolia => write!(f, "sepolia"),
             Network::Local => write!(f, "local"),
+            Network::Custom => write!(f, "custom"),
         }
     }
 }
@@ -35,6 +37,7 @@ impl FromStr for Network {
             "mainnet" => Ok(Network::Mainnet),
             "sepolia" => Ok(Network::Sepolia),
             "local" => Ok(Network::Local),
+            "custom" => Ok(Network::Custom),
             _ => Err(anyhow!("Unknown network: {}", s)),
         }
     }
@@ -77,6 +80,7 @@ impl Display for VerifyJobStatus {
 /**
  * Currently only GetJobStatus and VerifyClass are public available apis.
  * In the future, the get class api should be moved to using public apis too.
+ * TODO: Change get class api to use public apis.
  */
 pub enum ApiEndpoints {
     GetClass,
@@ -104,18 +108,26 @@ impl ApiEndpoints {
 
 pub fn get_network_api(network: Network) -> (String, String) {
     let url = match network {
-        Network::Mainnet => "https://voyager.online",
-        Network::Sepolia => "https://sepolia.voyager.online",
-        Network::Local => "http://localhost:8899",
+        Network::Mainnet => "https://voyager.online".to_string(),
+        Network::Sepolia => "https://sepolia.voyager.online".to_string(),
+        Network::Local => "http://localhost:8899".to_string(),
+        Network::Custom => match env::var("CUSTOM_INTERNAL_API_ENDPOINT_URL") {
+            std::result::Result::Ok(url) => url.to_string(),
+            _ => "".to_string(),
+        },
     };
 
     let public_url = match network {
-        Network::Mainnet => "https://api.voyager.online/beta",
-        Network::Sepolia => "https://sepolia-api.voyager.online/beta",
-        Network::Local => "http://localhost:30380",
+        Network::Mainnet => "https://api.voyager.online/beta".to_string(),
+        Network::Sepolia => "https://sepolia-api.voyager.online/beta".to_string(),
+        Network::Local => "http://localhost:30380".to_string(),
+        Network::Custom => match env::var("CUSTOM_PUBLIC_API_ENDPOINT_URL") {
+            std::result::Result::Ok(url) => url.to_string(),
+            _ => "".to_string(),
+        },
     };
 
-    (url.into(), public_url.into())
+    (url, public_url)
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -304,4 +316,38 @@ pub fn poll_verification_status(
     Err(anyhow!(
         "Timeout: Verification job took too long to complete"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_getting_default_voyager_endpoints() {
+        let selected_network = Network::Sepolia;
+        let actual_network_api = get_network_api(selected_network);
+
+        // Assert that the internal api is correct
+        assert_eq!(actual_network_api.0, "https://sepolia.voyager.online");
+        // Assert that the public api is correct``
+        assert_eq!(actual_network_api.1, "https://sepolia-api.voyager.online/beta");
+    }
+
+    #[test]
+    fn test_getting_custom_endpoints() {
+        let my_internal_api_url = "https://my-instance-internal-api.com";
+        let my_public_api_url = "https://my-instance-public-api.com";
+        // set env vars for this testing case
+        env::set_var("CUSTOM_INTERNAL_API_ENDPOINT_URL", my_internal_api_url);
+        env::set_var("CUSTOM_PUBLIC_API_ENDPOINT_URL", my_public_api_url);
+
+        let selected_network = Network::Custom;
+        let actual_network_api = get_network_api(selected_network);
+
+        // Assert that the internal api is correct
+        assert_eq!(actual_network_api.0, my_internal_api_url);
+        // Assert that the public api is correct``
+        assert_eq!(actual_network_api.1, my_public_api_url);
+    }
 }

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -182,7 +182,10 @@ fn main() -> anyhow::Result<()> {
 
         network_items[network_index]
     } else {
-        println!("🔔 {}", style("Custom verification endpoint provided:").bold());
+        println!(
+            "🔔 {}",
+            style("Custom verification endpoint provided:").bold()
+        );
         println!(
             "Internal endpoint url: {}",
             custom_internal_api_endpoint_url.unwrap_or("".to_string())


### PR DESCRIPTION
This PR adds support for custom verification endpoint via allowing verification endpoints to be passed with 2 env vars `CUSTOM_INTERNAL_API_ENDPOINT_URL` & `CUSTOM_PUBLIC_API_ENDPOINT_URL`.  This will be consolidated into one endpoint env vars in the future once the backend changes to reflect that too.

This should then allow anyone to plug in their own verification endpoints to the verifier without changing the code.

Closes #44.