### PR TITLE
chore: remove scarb as dependency (WIP)

### DIFF
--- a/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
+++ b/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, ensure, Context, Result};
-use scarb::flock::Filesystem;
+use camino::Utf8Path;
 use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -135,7 +135,7 @@ pub fn get_table_mut<'a>(doc: &'a mut Document, path: &[&str]) -> Result<&'a mut
 /// * Generating an updated Scarb.toml file fails.
 pub fn generate_scarb_updated_files(
     scarb_metadata: scarb_metadata::Metadata,
-    target_dir: &Filesystem,
+    target_dir: &Utf8Path,
     required_modules: Vec<&CairoModule>,
 ) -> Result<()> {
     let mut metadata = scarb_metadata.clone();
@@ -153,7 +153,10 @@ pub fn generate_scarb_updated_files(
 
     for package in metadata.packages {
         let manifest_path = package.manifest_path;
-        let target_path = target_dir.path_existent()?.join(package.name);
+        if !target_dir.exists() {
+            return Err(anyhow!("unable to locate target dir"));
+        }
+        let target_path = target_dir.join(package.name);
         generate_updated_scarb_toml(
             manifest_path.into_std_path_buf(),
             target_path.as_std_path(),


### PR DESCRIPTION
As we move towards having a universal verifier, we aim to reduce dependencies that associate with a specific version of cairo. Scarb is one such dependency that in the first place does not support being imported as a library.

We want to first remove Scarb as our dependency, keeping those that are supported as a library (`scarb-metadata` & `scarb-ui`), and try to utilize cairo deps to replace their functionality. This should make the maintenance easier and also reduce bugs that are caused by this misuse of Scarb as a library.