### PR TITLE
fix: attempt to fix mod not found issue via delays

### DIFF
--- a/crates/voyager-resolver-cairo/src/compiler/mod.rs
+++ b/crates/voyager-resolver-cairo/src/compiler/mod.rs
@@ -8,6 +8,8 @@ use scarb_utils::get_external_nonlocal_packages;
 use std::clone;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::Duration;
 
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_diagnostics::ToOption;
@@ -217,6 +219,14 @@ impl Compiler for VoyagerGenerator {
 
         let package_name = unit.main_component().package.id.name.to_string();
         let generated_crate_dir = target_dir.path_existent().unwrap().join(package_name);
+
+        // Problem with this step is that sometimes the build happens faster than the Scarb.toml is actually created and detected.
+        // For some weird reason this is only an issue before cairo 2.6?
+        // Adding this artificial delay here in order to hopefully resolve this, or at least reduce its occurrences.
+        // TODO: actually addressing this, or not. Likely related to this https://github.com/rust-lang/rust/issues/51775
+        // likely also related to the fact that during compilation and resolving the git cloned libraries takes some time to be
+        // pulled and updated, which might have caused this.
+        sleep(Duration::from_secs(2));
 
         // Locally run scarb build to make sure that everything compiles correctly before sending the files to voyager.
         run_scarb_build(generated_crate_dir.as_str())?;

--- a/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
+++ b/crates/voyager-resolver-cairo/src/compiler/scarb_utils.rs
@@ -4,7 +4,8 @@ use scarb::flock::Filesystem;
 use scarb_metadata::Metadata;
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::fs;
+use std::fs::{self, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use toml_edit::{Document, Formatted, InlineTable, Item, Table, Value};
@@ -193,13 +194,6 @@ pub fn generate_scarb_updated_files(
             &required_packages,
             &external_packages,
         )?;
-
-        // Problem with this step is that sometimes the build happens faster than the Scarb.toml is actually created and detected.
-        // as such adding a checking step here in order to check and at the same time artificially slow down this process.
-        // For some weird reason this is only an issue before cairo 2.6?
-        if !manifest_path.exists() {
-            return Err(anyhow!("Files not created correctly."))
-        }
     }
 
     Ok(())


### PR DESCRIPTION
Currently there's a likely race condition when the dependencies are being resolved, where the final build on the resolved projects fails although the resolved project is correct. This is likely due to the dependencies file updates that might happen when Scarb build happens which causes some dependency to go missing in the middle of the build.

A quick fix is just to add a artificial delay in order to hopefully wait until the files are fully updated before the build runs. This is of course non-deterministic and not ideal, but we are aiming to address this in the future by not relying on the files to be updated to build.